### PR TITLE
exclude sys

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ matplotlib
 scipy
 numpy
 seaborn
-sys


### PR DESCRIPTION
accept because it causes this error: Using uv pip install.

  × No solution found when resolving dependencies:

  ╰─▶ Because sys was not found in the package registry and you require sys,

      we can conclude that the requirements are unsatisfiable.

Checking if Streamlit is installed